### PR TITLE
add "party mode" with comic sans, marquee text, rainbow background

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -47,6 +47,16 @@ html {
 
 body {
   margin: 2em 1em 5em;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+
+  &.partyMode {
+    font-family: "Comic Sans MS", "Comic Sans";
+  }
 }
 
 h1,h2,h3,h4,h5,h6 {
@@ -184,6 +194,10 @@ td {
   outline: solid 1px var(--table-border-color);
 }
 
+tbody tr:nth-child(even) {
+  background-color: var(--background-main-color);
+}
+
 tbody tr:nth-child(odd) {
   background-color: var(--table-highlight-color);
 }
@@ -195,6 +209,37 @@ tbody tr:nth-child(odd) td {
 
 .mobileDisplay {
   display: none;
+}
+
+.partyDisplayBlock {
+  display: none;
+}
+
+.partyMode {
+  .partyDisplayBlock {
+    display: block;
+  }
+
+  .partyHide {
+    display: none;
+  }
+}
+
+html:has(.partyMode) {
+  background: linear-gradient(
+    90deg,
+    rgba(255, 0, 0, 1) 0%,
+    rgba(255, 154, 0, 1) 10%,
+    rgba(208, 222, 33, 1) 20%,
+    rgba(79, 220, 74, 1) 30%,
+    rgba(63, 218, 216, 1) 40%,
+    rgba(47, 201, 226, 1) 50%,
+    rgba(28, 127, 238, 1) 60%,
+    rgba(95, 21, 242, 1) 70%,
+    rgba(186, 12, 248, 1) 80%,
+    rgba(251, 7, 217, 1) 90%,
+    rgba(255, 0, 0, 1) 100%
+  );
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/components/PartyModeToggle.js
+++ b/src/components/PartyModeToggle.js
@@ -1,0 +1,17 @@
+const PartyModeToggle= ({ partyMode, setPartyMode }) => {
+    const onClick = () => {
+        const newPartyMode = !partyMode;
+        setPartyMode(newPartyMode);
+        document.body.classList.toggle('partyMode', newPartyMode);
+        const marqs = document.getElementsByTagName('marquee');
+        console.log(marqs);
+        newPartyMode ? marqs[0].start() : marqs[0].stop();
+    };
+
+    return (
+        <button className="button partyToggle" onClick={onClick}>{partyMode ? 'Kill the Party' : 'Enable Party Mode'}</button>
+    );
+
+};
+
+export default PartyModeToggle;

--- a/src/containers/ItemIndex.js
+++ b/src/containers/ItemIndex.js
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import Form from "../components/Form";
+import PartyModeToggle from "../components/PartyModeToggle";
 import TableContainer from "./TableContainer.js";
 import { getItems } from "../services/EthelAPI.js";
 
@@ -11,15 +12,18 @@ const ItemIndex = () => {
     points: "",
     rating: "Caution",
   });
+  const [partyMode, setPartyMode] = useState(false);
   const [items, setItems] = useState([]);
   const hasItems = items.length > 0;
   const fetchItems = () => getItems(formData).then(setItems);
   const render = (
     <>
       <h1>The Item-Tum Tugger</h1>
-      <marquee>
+      <marquee className="partyDisplayBlock">
         <h3>Is a curious app</h3>
       </marquee>
+      <h3 className="partyHide">Is a curious app</h3>
+      <PartyModeToggle partyMode={partyMode} setPartyMode={setPartyMode} />
       <Form
         formData={formData}
         setFormData={setFormData}

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,3 @@
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-weight: 400;
-}
-
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;


### PR DESCRIPTION
The button to toggle party mode is probably too prominent right now, and the headline font color could probably be improved (white with a black text outline, perhaps?) but party mode _exists_ now
<img width="872" alt="Screenshot 2023-05-23 at 6 21 20 PM" src="https://github.com/GASH-SCAV/big-list-frontend/assets/284712/85a8ecf6-fa6c-4a31-82af-eb4ae7387826">
<img width="870" alt="Screenshot 2023-05-23 at 6 21 36 PM" src="https://github.com/GASH-SCAV/big-list-frontend/assets/284712/ad4d59af-fcdf-476e-ad74-c58a8d8daa30">
